### PR TITLE
Add meta keyboard modifier for touch zooming

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.3.1"
+agp = "8.4.1"
 android-compileSdk = "34"
 android-minSdk = "24"
 android-targetSdk = "34"

--- a/library/src/commonMain/kotlin/ovh/plrapps/mapcompose/ui/gestures/TapGestureDetector.kt
+++ b/library/src/commonMain/kotlin/ovh/plrapps/mapcompose/ui/gestures/TapGestureDetector.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.input.pointer.AwaitPointerEventScope
 import androidx.compose.ui.input.pointer.PointerEventTimeoutCancellationException
 import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.PointerInputScope
+import androidx.compose.ui.input.pointer.isMetaPressed
 import androidx.compose.ui.input.pointer.positionChanged
 import androidx.compose.ui.input.pointer.util.VelocityTracker
 import androidx.compose.ui.platform.ViewConfiguration
@@ -41,7 +42,7 @@ private val NoPressGesture: suspend PressGestureScope.(Offset) -> Unit = { }
  * second tap, and a double-tap can no-longer timeout.
  */
 internal suspend fun PointerInputScope.detectTapGestures(
-    onDoubleTap: ((Offset) -> Unit)? = null,
+    onDoubleTap: ((Offset, Boolean) -> Unit)? = null,
     onDoubleTapZoom: (centroid: Offset, zoom: Float) -> Unit,
     onDoubleTapZoomFling: (centroid: Offset, velocity: Float) -> Unit,
     onLongPress: ((Offset) -> Unit)? = null,
@@ -115,7 +116,6 @@ internal suspend fun PointerInputScope.detectTapGestures(
                     if (onPress !== NoPressGesture) {
                         launch { pressScope.onPress(secondDown.position) }
                     }
-
                     // Now, either double-tap or zoom gesture. This is where we deviate
                     // from the framework : no timeout to detect long-press.
                     val secondUp = waitForUpOrCancellation()
@@ -124,7 +124,7 @@ internal suspend fun PointerInputScope.detectTapGestures(
                         launch {
                             pressScope.release()
                         }
-                        onDoubleTap(secondUp.position)
+                        onDoubleTap(secondUp.position, currentEvent.keyboardModifiers.isMetaPressed)
                     } else {
                         val zoomVelocityTracker = VelocityTracker()
                         var pan = Offset.Zero

--- a/library/src/commonMain/kotlin/ovh/plrapps/mapcompose/ui/layout/ZoomPanRotate.kt
+++ b/library/src/commonMain/kotlin/ovh/plrapps/mapcompose/ui/layout/ZoomPanRotate.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.Velocity
 import kotlinx.coroutines.CoroutineScope
+import ovh.plrapps.mapcompose.ui.gestures.detectScrollGesture
 import ovh.plrapps.mapcompose.ui.gestures.detectTransformGestures
 import ovh.plrapps.mapcompose.ui.gestures.detectTapGestures
 
@@ -49,7 +50,7 @@ internal fun ZoomPanRotate(
                 if (!gestureListener.isListeningForGestures()) return@pointerInput
                 detectTapGestures(
                     onTap = { offset -> gestureListener.onTap(offset) },
-                    onDoubleTap = { offset -> gestureListener.onDoubleTap(offset) },
+                    onDoubleTap = { offset, isZoomOut -> gestureListener.onDoubleTap(offset, isZoomOut) },
                     onDoubleTapZoom = { centroid, zoom -> gestureListener.onScaleRatio(zoom, centroid)},
                     onDoubleTapZoomFling = { centroid, velocity ->
                         gestureListener.onFlingZoom(velocity, centroid)
@@ -89,7 +90,7 @@ internal interface GestureListener {
     fun onTouchDown()
     fun onPress()
     fun onTap(focalPt: Offset)
-    fun onDoubleTap(focalPt: Offset)
+    fun onDoubleTap(focalPt: Offset, isZoomOut: Boolean = false)
     fun onTwoFingersTap(focalPt: Offset)
     fun onLongPress(focalPt: Offset)
     fun isListeningForGestures(): Boolean

--- a/library/src/commonMain/kotlin/ovh/plrapps/mapcompose/ui/state/ZoomPanRotateState.kt
+++ b/library/src/commonMain/kotlin/ovh/plrapps/mapcompose/ui/state/ZoomPanRotateState.kt
@@ -470,14 +470,18 @@ internal class ZoomPanRotateState(
         return block(xPx, yPx)
     }
 
-    override fun onDoubleTap(focalPt: Offset) {
+    override fun onDoubleTap(focalPt: Offset, isZoomOut: Boolean) {
         if (!isZoomingEnabled) return
 
-        val destScale = (
-                2.0.pow(floor(ln((scale * 2).toDouble()) / ln(2.0))).toFloat()
-                ).let {
+        val destScale = if (!isZoomOut) {
+            (2.0.pow(floor(ln((scale * 2).toDouble()) / ln(2.0))).toFloat()).let {
                 if (shouldLoopScale && it > maxScale) minScale else it
             }
+        } else {
+            (2.0.pow(floor(ln((scale / 2).toDouble()) / ln(2.0))).toFloat()).let {
+                if (shouldLoopScale && it < minScale) maxScale else it
+            }
+        }
 
         val angleRad = -rotation.toRad()
         val focalPtRotated = rotateFocalPoint(focalPt, angleRad)
@@ -527,7 +531,6 @@ internal class ZoomPanRotateState(
             }
         }
     }
-
     override fun onSizeChanged(composableScope: CoroutineScope, size: IntSize) {
         scope = composableScope
 


### PR DESCRIPTION
Add meta keyboard modifier for touch zooming 
Press keyboard meta key (macbook command key) will do zoom out instead of zoom in